### PR TITLE
Stronger tests

### DIFF
--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -11,14 +11,16 @@
     <p><%= link_to pet.name, "/pets/#{pet.id}" %></p>
 <% end %>
 
-<section class='submission'>
-  <h2> Submit this Application</h2>
-  <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
-    <%= f.label :description, "Why would you make a good owner for these pets?" %>
-    <%= f.text_field :description %>
-    <%= f.submit "Submit" %>
-  <% end %>
-</section>
+<% if @pets.present? %>
+  <section class='submission'>
+    <h2> Submit this Application</h2>
+    <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
+      <%= f.label :description, "Why would you make a good owner for these pets?" %>
+      <%= f.text_field :description %>
+      <%= f.submit "Submit" %>
+    <% end %>
+  </section>
+<% end %>
 
 <% if @application.status == "In Progress" %>
   <section class='application'>

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe 'Admin Application Show page' do
       # And instead I see buttons to approve or reject the pet for this specific application
       expect(page).to have_button("Approve: Lucille Bald")
       expect(page).to have_button("Reject: Lucille Bald")
+      expect(page).to_not have_content("Lucille Bald: Approved")
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'Application Show page' do
     # And under the search bar I see any Pet whose name matches my search
     within '.pets_found' do
       expect(page).to have_content("Lucille Bald")
+      expect(page).to_not have_content("Lobster")
     end
   end
 
@@ -73,6 +74,7 @@ RSpec.describe 'Application Show page' do
     within '.pets_found' do
       expect(page).to have_content(@pet_1.name)
       expect(page).to have_link(@pet_1.name)
+      expect(page).to_not have_link(@pet_2.name)
       expect(page).to have_button("Adopt this Pet")
       # When I click one of these buttons
       click_button("Adopt this Pet")
@@ -103,6 +105,7 @@ RSpec.describe 'Application Show page' do
     # Then I am taken back to the application's show page
     expect(current_path).to eq("/applications/#{@app_1.id}")
     # And I see an indicator that the application is "Pending"
+    expect(page).to_not have_content("Status: In Progress")
     expect(page).to have_content("Status: Pending")
     # And I see all the pets that I want to adopt
     expect(page).to have_content(@pet_1.name)
@@ -119,7 +122,7 @@ RSpec.describe 'Application Show page' do
     expect(page).to_not have_content(@pet_1.name)
     expect(page).to_not have_content(@pet_2.name)
     # Then I do not see a section to submit my application
-    expect(page).to_not have_content(".submission")
+    expect(page).to_not have_css(".submission")
   end
 
   # 8. Partial Matches for Pet Names


### PR DESCRIPTION
Added sad paths for applications/show_spec.rb US4, US5, modified line 125 to - to_not have_css(".submission") then had to add an <% if @pets.present? %> statement above the submission section on the views/applications/show.html.erb so the section only shows if there are pets added to the application.  Before you had it as expect(page).to_not have_content(".submission"), so it was looking for that exact string, not the class section, thats why it was passing before, but it wasn't actually doing what it should have based off of the story test. Also,  made a sad path for story 14 admin/applications/show_spec.rb.
